### PR TITLE
Added members page with table, sort, and summary

### DIFF
--- a/layouts/members/members.html
+++ b/layouts/members/members.html
@@ -1,118 +1,133 @@
 {{ define "main" }}
 <link rel="stylesheet" href="/css/members.css">
 
-<!-- Page Title -->
-<h1><br><br>{{ .Title }}</h1>
+<!-- Full-width wrapper using Docsy's theme-aware styling -->
+<div class="container-fluid px-4 my-theme-aware-content" style="color: var(--text-color); background-color: var(--bg-color);">
 
-<!-- Hebrew Description -->
-<p dir="rtl" class="text-right">
-  בדף זה תוכלו לראות את רשימת התורמים לקהילה, כולל מידע על תרומתם: קומיטים, בקשות משיכה, תגובות ומספר פרויקטים בהם השתתפו. ניתן למיין ולחפש לפי שם או לפי כמות תרומות.
-</p>
+  <!-- Page Title -->
+  <h1><br><br>{{ .Title }}</h1>
 
-<div dir="ltr">
-
-  <!-- ========================
-    Search & Sort Controls
-  ========================= -->
-  <div class="d-flex flex-wrap gap-3 align-items-end mb-4">
-    <div>
-      <label for="searchInput" class="form-label mb-1">Search by username:</label>
-      <input type="text" class="form-control" id="searchInput" onkeyup="filterTable()" placeholder="Type a username..." />
-    </div>
-
-    <div>
-      <label for="sortOption" class="form-label mb-1">Sort by:</label>
-      <select class="form-control" id="sortOption" onchange="sortTable()">
-        <option value="alpha">Alphabetical (A–Z)</option>
-        <option value="most">Most Contributions</option>
-        <option value="least">Least Contributions</option>
-      </select>
-    </div>
-  </div>
-
-  <!-- ========================
-    Community Summary Section
-  ========================= -->
-  {{ $totalCommits := 0 }}
-  {{ $totalPRs := 0 }}
-  {{ $totalIssues := 0 }}
-  {{ $totalPRComments := 0 }}
-  {{ $totalIssueComments := 0 }}
-  {{ $totalUsers := 0 }}
-  {{ $uniqueProjects := dict }}
-
-  {{ range .Site.Data.remote }}
-    {{ $totalUsers = add $totalUsers 1 }}
-    {{ $totalCommits = add $totalCommits .summary.totalCommits }}
-    {{ $totalPRs = add $totalPRs .summary.totalPRs }}
-    {{ $totalIssues = add $totalIssues .summary.totalIssues }}
-    {{ $totalPRComments = add $totalPRComments .summary.totalPRComments }}
-    {{ $totalIssueComments = add $totalIssueComments .summary.totalIssueComments }}
-    {{ range .repos }}
-      {{ $uniqueProjects = merge $uniqueProjects (dict .url true) }}
-    {{ end }}
-  {{ end }}
-
-  <div class="community-summary">
-    <strong>Community Summary:</strong><br>
-    Contributors: {{ $totalUsers }} |
-    Projects: {{ len $uniqueProjects }} |
-    Commits: {{ $totalCommits }} |
-    PRs: {{ $totalPRs }} |
-    Issues: {{ $totalIssues }} |
-    PR Comments: {{ $totalPRComments }} |
-    Issue Comments: {{ $totalIssueComments }}
-  </div>
-
-  <!-- ===================
-    Contributors Table
-  ====================== -->
-  <div class="table-container">
-    <table id="contributorsTable" class="table table-bordered table-dark">
-      <thead class="thead-dark">
-        <tr>
-          <th>Username</th> <!-- TODO: replace with name when avialable and then fix the searchbox and search function -->
-          <th>Total Contributions</th>
-          <th>Details</th>
-        </tr>
-      </thead>
-      <tbody>
-        {{ range .Site.Data.remote }}
-          {{ $total := add (add (add (add .summary.totalCommits .summary.totalPRs) .summary.totalIssues) .summary.totalPRComments) .summary.totalIssueComments }}
-          <tr>
-            <td>{{ .username }}</td> <!-- TODO: replace with .name when available -->
-            <td class="total">{{ $total }}</td>
-            <td>
-              <ul>
-                <li>Commits: {{ .summary.totalCommits }}</li>
-                <li>PRs: {{ .summary.totalPRs }}</li>
-                <li>Issues: {{ .summary.totalIssues }}</li>
-                <li>PR Comments: {{ .summary.totalPRComments }}</li>
-                <li>Issue Comments: {{ .summary.totalIssueComments }}</li>
-                <li>Projects Contributed To: {{ len .repos }}</li>
-              </ul>
-              {{ if gt (len .repos) 0 }}
-              <details class="projects-toggle">
-                <summary>Show Projects</summary>
-                <ul class="project-list">
-                  {{ range .repos }}
-                    <li><a href="{{ .url }}" target="_blank">{{ .repoName }}</a>  {{ .description }}</li>
-                  {{ end }}
-                </ul>
-              </details>
-              {{ end }}
-            </td>
-          </tr>
-        {{ end }}
-      </tbody>
-    </table>
-  </div>
-
-  <p class="last-updated">
-    Last updated: {{ .Site.Data.remoteGeneratedAt }}
+  <!-- Hebrew Description -->
+  <p dir="rtl" class="text-right">
+    בדף זה תוכלו לראות את רשימת התורמים לקהילה, כולל מידע על תרומתם: קומיטים, בקשות משיכה, תגובות ומספר פרויקטים בהם השתתפו. ניתן למיין ולחפש לפי שם או לפי כמות תרומות.
   </p>
+
+  <div dir="ltr">
+    <!-- ========================
+      Search & Sort Controls
+    ========================= -->
+    <div class="d-flex flex-wrap gap-3 align-items-end mb-4">
+      <div>
+        <label for="searchInput" class="form-label mb-1">Search by username:</label>
+        <input type="text" class="form-control text-reset" id="searchInput" onkeyup="filterTable()" placeholder="Type a username..." />
+      </div>
+
+      <div>
+        <label for="sortOption" class="form-label mb-1">Sort by:</label>
+        <select class="form-control text-reset" id="sortOption" onchange="sortTable()">
+          <option value="alpha">Alphabetical (A–Z)</option>
+          <option value="most">Most Contributions</option>
+          <option value="least">Least Contributions</option>
+        </select>
+      </div>
+    </div>
+
+    <!-- ========================
+      Community Summary Section
+    ========================= -->
+    {{ $totalCommits := 0 }}
+    {{ $totalPRs := 0 }}
+    {{ $totalIssues := 0 }}
+    {{ $totalPRComments := 0 }}
+    {{ $totalIssueComments := 0 }}
+    {{ $totalUsers := 0 }}
+    {{ $uniqueProjects := dict }}
+
+    {{ range .Site.Data.remote }}
+      {{ $totalUsers = add $totalUsers 1 }}
+      {{ $totalCommits = add $totalCommits .summary.totalCommits }}
+      {{ $totalPRs = add $totalPRs .summary.totalPRs }}
+      {{ $totalIssues = add $totalIssues .summary.totalIssues }}
+      {{ $totalPRComments = add $totalPRComments .summary.totalPRComments }}
+      {{ $totalIssueComments = add $totalIssueComments .summary.totalIssueComments }}
+      {{ range .repos }}
+        {{ $uniqueProjects = merge $uniqueProjects (dict .url true) }}
+      {{ end }}
+    {{ end }}
+
+    <div class="community-summary my-3">
+      <strong>Community Summary:</strong><br>
+      Contributors: {{ $totalUsers }} |
+      Projects: {{ len $uniqueProjects }} |
+      Commits: {{ $totalCommits }} |
+      PRs: {{ $totalPRs }} |
+      Issues: {{ $totalIssues }} |
+      PR Comments: {{ $totalPRComments }} |
+      Issue Comments: {{ $totalIssueComments }}
+    </div>
+
+    <!-- ===================
+      Contributors Table
+    ====================== -->
+    <div class="table-container mb-4">
+      <table id="contributorsTable" class="table table-bordered text-reset w-100">
+        <thead>
+          <tr>
+            <th>Username</th>
+            <th>Total</th>
+            <th>Commits</th>
+            <th>PRs</th>
+            <th>Issues</th>
+            <th>PR Comments</th>
+            <th>Issue Comments</th>
+            <th>Projects</th>
+          </tr>
+        </thead>
+        <tbody>
+          {{ range .Site.Data.remote }}
+            {{ $total := add (add (add (add .summary.totalCommits .summary.totalPRs) .summary.totalIssues) .summary.totalPRComments) .summary.totalIssueComments }}
+            <tr>
+              <td>
+                <div class="username-cell d-flex align-items-center gap-2">
+                  <img src="https://github.com/{{ .username }}.png" alt="{{ .username }}" class="avatar" />
+                  {{ .username }}
+                </div>
+              </td>
+              <td class="total">{{ $total }}</td>
+              <td>{{ .summary.totalCommits }}</td>
+              <td>{{ .summary.totalPRs }}</td>
+              <td>{{ .summary.totalIssues }}</td>
+              <td>{{ .summary.totalPRComments }}</td>
+              <td>{{ .summary.totalIssueComments }}</td>
+              <td>
+                {{ if gt (len .repos) 0 }}
+                  <details class="projects-toggle">
+                    <summary>{{ len .repos }} projects</summary>
+                    <ul class="project-list mt-2">
+                      {{ range .repos }}
+                        <li><a href="{{ .url }}" target="_blank">{{ .repoName }}</a> – {{ .description }}</li>
+                      {{ end }}
+                    </ul>
+                  </details>
+                {{ else }}
+                  —
+                {{ end }}
+              </td>
+            </tr>
+          {{ end }}
+        </tbody>
+      </table>
+    </div>
+
+    <p class="last-updated mb-5">
+      Last updated: {{ .Site.Data.remoteGeneratedAt }}
+    </p>
+  </div>
 </div>
 
+<!-- ========================
+  Scripts for Sort & Filter
+========================= -->
 <script>
   function sortTable() {
     const table = document.getElementById("contributorsTable");

--- a/layouts/members/members.html
+++ b/layouts/members/members.html
@@ -1,28 +1,122 @@
 {{ define "main" }}
+<link rel="stylesheet" href="/css/members.css">
 
-     
-  <h1><br><br>{{ .Title }}</h1>
-  הדף נמצא בבנייה
-  <ul>
-    {{ range .Site.Data.remote }}
-      <li>
-        <strong>{{ .username }}</strong>
-        <ul>
-          {{ range .repos }}
-            <li>
-              <a href="{{ .url }}">{{ .repoName }}</a> - {{ .description }}
+<h1><br><br>{{ .Title }}</h1>
+<p dir="rtl" style="text-align: right;">
+  בדף זה תוכלו לראות את רשימת התורמים לקהילה, כולל מידע על תרומתם: קומיטים, בקשות משיכה, דיוני באגים ותגובות. ניתן למיין ולחפש לפי שם או לפי כמות תרומות.
+</p>
+
+
+<div dir="ltr">
+  <!-- Search and Sort -->
+  <div class="filter-controls">
+    <label for="searchInput">Search by username:</label>
+    <input type="text" id="searchInput" onkeyup="filterTable()" placeholder="Type a username..." />
+
+    <label for="sortOption" style="margin-left: 1rem;">Sort by:</label>
+    <select id="sortOption" onchange="sortTable()">
+      <option value="alpha">Alphabetical (A–Z)</option>
+      <option value="most">Most Contributions</option>
+      <option value="least">Least Contributions</option>
+    </select>
+  </div>
+
+  <!-- Summary -->
+  {{ $totalCommits := 0 }}
+  {{ $totalPRs := 0 }}
+  {{ $totalIssues := 0 }}
+  {{ $totalPRComments := 0 }}
+  {{ $totalIssueComments := 0 }}
+  {{ $totalUsers := 0 }}
+
+  {{ range .Site.Data.remote }}
+    {{ $totalUsers = add $totalUsers 1 }}
+    {{ $totalCommits = add $totalCommits .summary.totalCommits }}
+    {{ $totalPRs = add $totalPRs .summary.totalPRs }}
+    {{ $totalIssues = add $totalIssues .summary.totalIssues }}
+    {{ $totalPRComments = add $totalPRComments .summary.totalPRComments }}
+    {{ $totalIssueComments = add $totalIssueComments .summary.totalIssueComments }}
+  {{ end }}
+
+  <div class="community-summary">
+    <strong>Community Summary:</strong><br>
+    Contributors: {{ $totalUsers }} |
+    Commits: {{ $totalCommits }} |
+    PRs: {{ $totalPRs }} |
+    Issues: {{ $totalIssues }} |
+    PR Comments: {{ $totalPRComments }} |
+    Issue Comments: {{ $totalIssueComments }}
+  </div>
+
+  <!-- Table -->
+  <div class="table-container">
+    <table id="contributorsTable">
+      <thead>
+        <tr>
+          <th>Username</th>
+          <th>Total Contributions</th>
+          <th>Details</th>
+        </tr>
+      </thead>
+      <tbody>
+        {{ range .Site.Data.remote }}
+          {{ $total := add (add (add (add .summary.totalCommits .summary.totalPRs) .summary.totalIssues) .summary.totalPRComments) .summary.totalIssueComments }}
+          <tr>
+            <td>{{ .username }}</td>
+            <td class="total">{{ $total }}</td>
+            <td>
               <ul>
-                <li>Commits: {{ .commits }}</li>
-                <li>PRs: {{ .pullRequests }}</li>
-                <li>Issues: {{ .issues }}</li>
-                <li>PR Comments: {{ .prComments }}</li>
-                <li>Issue Comments: {{ .issueComments }}</li>
+                <li>Commits: {{ .summary.totalCommits }}</li>
+                <li>PRs: {{ .summary.totalPRs }}</li>
+                <li>Issues: {{ .summary.totalIssues }}</li>
+                <li>PR Comments: {{ .summary.totalPRComments }}</li>
+                <li>Issue Comments: {{ .summary.totalIssueComments }}</li>
               </ul>
-            </li>
-          {{ end }}
-        </ul>
-        <em>Summary: Commits: {{ .summary.totalCommits }}, PRs: {{ .summary.totalPRs }}, Issues: {{ .summary.totalIssues }}, PR Comments: {{ .summary.totalPRComments }}, Issue Comments: {{ .summary.totalIssueComments }}</em>
-      </li>
-    {{ end }}
-  </ul>
+            </td>
+          </tr>
+        {{ end }}
+      </tbody>
+    </table>
+  </div>
+
+  <!-- Last updated -->
+  <p class="last-updated">
+    Last updated: {{ .Site.Data.remoteGeneratedAt }}
+  </p>
+</div>
+
+<!-- Scripts -->
+<script>
+  function sortTable() {
+    const table = document.getElementById("contributorsTable");
+    const tbody = table.querySelector("tbody");
+    const rows = Array.from(tbody.querySelectorAll("tr"));
+    const option = document.getElementById("sortOption").value;
+
+    rows.sort((a, b) => {
+      const nameA = a.cells[0].textContent.trim().toLowerCase();
+      const nameB = b.cells[0].textContent.trim().toLowerCase();
+      const contribA = parseInt(a.cells[1].textContent.trim());
+      const contribB = parseInt(b.cells[1].textContent.trim());
+
+      if (option === "most") return contribB - contribA;
+      if (option === "least") return contribA - contribB;
+      if (option === "alpha") return nameA.localeCompare(nameB);
+    });
+
+    tbody.innerHTML = "";
+    rows.forEach(row => tbody.appendChild(row));
+  }
+
+  function filterTable() {
+    const input = document.getElementById("searchInput");
+    const filter = input.value; // Case-sensitive
+    const rows = document.querySelectorAll("#contributorsTable tbody tr");
+
+    rows.forEach(row => {
+      const username = row.cells[0].textContent;
+      row.style.display = username.includes(filter) ? "" : "none";
+    });
+  }
+</script>
 {{ end }}

--- a/layouts/members/members.html
+++ b/layouts/members/members.html
@@ -1,33 +1,45 @@
 {{ define "main" }}
 <link rel="stylesheet" href="/css/members.css">
 
+<!-- Page Title -->
 <h1><br><br>{{ .Title }}</h1>
-<p dir="rtl" style="text-align: right;">
-  בדף זה תוכלו לראות את רשימת התורמים לקהילה, כולל מידע על תרומתם: קומיטים, בקשות משיכה, דיוני באגים ותגובות. ניתן למיין ולחפש לפי שם או לפי כמות תרומות.
+
+<!-- Hebrew Description -->
+<p dir="rtl" class="text-right">
+  בדף זה תוכלו לראות את רשימת התורמים לקהילה, כולל מידע על תרומתם: קומיטים, בקשות משיכה, תגובות ומספר פרויקטים בהם השתתפו. ניתן למיין ולחפש לפי שם או לפי כמות תרומות.
 </p>
 
-
 <div dir="ltr">
-  <!-- Search and Sort -->
-  <div class="filter-controls">
-    <label for="searchInput">Search by username:</label>
-    <input type="text" id="searchInput" onkeyup="filterTable()" placeholder="Type a username..." />
 
-    <label for="sortOption" style="margin-left: 1rem;">Sort by:</label>
-    <select id="sortOption" onchange="sortTable()">
-      <option value="alpha">Alphabetical (A–Z)</option>
-      <option value="most">Most Contributions</option>
-      <option value="least">Least Contributions</option>
-    </select>
+  <!-- ========================
+    Search & Sort Controls
+  ========================= -->
+  <div class="d-flex flex-wrap gap-3 align-items-end mb-4">
+    <div>
+      <label for="searchInput" class="form-label mb-1">Search by username:</label>
+      <input type="text" class="form-control" id="searchInput" onkeyup="filterTable()" placeholder="Type a username..." />
+    </div>
+
+    <div>
+      <label for="sortOption" class="form-label mb-1">Sort by:</label>
+      <select class="form-control" id="sortOption" onchange="sortTable()">
+        <option value="alpha">Alphabetical (A–Z)</option>
+        <option value="most">Most Contributions</option>
+        <option value="least">Least Contributions</option>
+      </select>
+    </div>
   </div>
 
-  <!-- Summary -->
+  <!-- ========================
+    Community Summary Section
+  ========================= -->
   {{ $totalCommits := 0 }}
   {{ $totalPRs := 0 }}
   {{ $totalIssues := 0 }}
   {{ $totalPRComments := 0 }}
   {{ $totalIssueComments := 0 }}
   {{ $totalUsers := 0 }}
+  {{ $uniqueProjects := dict }}
 
   {{ range .Site.Data.remote }}
     {{ $totalUsers = add $totalUsers 1 }}
@@ -36,11 +48,15 @@
     {{ $totalIssues = add $totalIssues .summary.totalIssues }}
     {{ $totalPRComments = add $totalPRComments .summary.totalPRComments }}
     {{ $totalIssueComments = add $totalIssueComments .summary.totalIssueComments }}
+    {{ range .repos }}
+      {{ $uniqueProjects = merge $uniqueProjects (dict .url true) }}
+    {{ end }}
   {{ end }}
 
   <div class="community-summary">
     <strong>Community Summary:</strong><br>
     Contributors: {{ $totalUsers }} |
+    Projects: {{ len $uniqueProjects }} |
     Commits: {{ $totalCommits }} |
     PRs: {{ $totalPRs }} |
     Issues: {{ $totalIssues }} |
@@ -48,12 +64,14 @@
     Issue Comments: {{ $totalIssueComments }}
   </div>
 
-  <!-- Table -->
+  <!-- ===================
+    Contributors Table
+  ====================== -->
   <div class="table-container">
-    <table id="contributorsTable">
-      <thead>
+    <table id="contributorsTable" class="table table-bordered table-dark">
+      <thead class="thead-dark">
         <tr>
-          <th>Username</th>
+          <th>Username</th> <!-- TODO: replace with name when avialable and then fix the searchbox and search function -->
           <th>Total Contributions</th>
           <th>Details</th>
         </tr>
@@ -62,7 +80,7 @@
         {{ range .Site.Data.remote }}
           {{ $total := add (add (add (add .summary.totalCommits .summary.totalPRs) .summary.totalIssues) .summary.totalPRComments) .summary.totalIssueComments }}
           <tr>
-            <td>{{ .username }}</td>
+            <td>{{ .username }}</td> <!-- TODO: replace with .name when available -->
             <td class="total">{{ $total }}</td>
             <td>
               <ul>
@@ -71,7 +89,18 @@
                 <li>Issues: {{ .summary.totalIssues }}</li>
                 <li>PR Comments: {{ .summary.totalPRComments }}</li>
                 <li>Issue Comments: {{ .summary.totalIssueComments }}</li>
+                <li>Projects Contributed To: {{ len .repos }}</li>
               </ul>
+              {{ if gt (len .repos) 0 }}
+              <details class="projects-toggle">
+                <summary>Show Projects</summary>
+                <ul class="project-list">
+                  {{ range .repos }}
+                    <li><a href="{{ .url }}" target="_blank">{{ .repoName }}</a>  {{ .description }}</li>
+                  {{ end }}
+                </ul>
+              </details>
+              {{ end }}
             </td>
           </tr>
         {{ end }}
@@ -79,13 +108,11 @@
     </table>
   </div>
 
-  <!-- Last updated -->
   <p class="last-updated">
     Last updated: {{ .Site.Data.remoteGeneratedAt }}
   </p>
 </div>
 
-<!-- Scripts -->
 <script>
   function sortTable() {
     const table = document.getElementById("contributorsTable");
@@ -101,7 +128,7 @@
 
       if (option === "most") return contribB - contribA;
       if (option === "least") return contribA - contribB;
-      if (option === "alpha") return nameA.localeCompare(nameB);
+      return nameA.localeCompare(nameB);
     });
 
     tbody.innerHTML = "";
@@ -110,11 +137,11 @@
 
   function filterTable() {
     const input = document.getElementById("searchInput");
-    const filter = input.value; // Case-sensitive
+    const filter = input.value.toLowerCase();
     const rows = document.querySelectorAll("#contributorsTable tbody tr");
 
     rows.forEach(row => {
-      const username = row.cells[0].textContent;
+      const username = row.cells[0].textContent.toLowerCase();
       row.style.display = username.includes(filter) ? "" : "none";
     });
   }

--- a/static/css/members.css
+++ b/static/css/members.css
@@ -1,89 +1,108 @@
-/* ========================
-   Base Styles
-======================== */
+/* Light Theme */
+html.light {
+  --bg-color: #ffffff;
+  --text-color: #111111;
+  --border-color: #cccccc;
+  --row-alt-color: #f9f9f9;
+  --thead-bg-color: #f2f2f2;
+  --link-color: #007bff;
+  --link-hover: #0056b3;
+}
+
+/* Dark Theme */
+html.dark {
+  --bg-color: #121212;
+  --text-color: #eeeeee;
+  --border-color: #444444;
+  --row-alt-color: #1e1e1e;
+  --thead-bg-color: #2a2a2a;
+  --link-color: #66b1ff;
+  --link-hover: #99ccff;
+}
+
+/* Apply CSS Variables */
 body {
-  background-color: #121212;
-  color: var(--body-color, #eee);
+  background-color: var(--bg-color);
+  color: var(--text-color);
 }
 
-/* ========================
-   Summary and Metadata
-======================== */
-.community-summary {
-  margin: 1rem 0;
+/* Expand content to full width */
+body > div {
+  max-width: 100%;
+  width: 100%;
+  padding: 0 2rem;
+  box-sizing: border-box;
 }
 
+.community-summary,
 .last-updated {
-  font-style: italic;
-  color: #aaa;
-  margin-top: 1rem;
+  color: var(--text-color);
 }
 
 /* ========================
    Table Styling
-======================== */
+========================= */
+.table-container {
+  width: 100%;
+  overflow-x: auto;
+}
+
+#contributorsTable {
+  width: 100%;
+  border-collapse: collapse;
+  background-color: var(--bg-color);
+  table-layout: auto;
+}
+
 #contributorsTable th,
 #contributorsTable td {
-  text-align: center;
-  vertical-align: middle;
+  color: var(--text-color);
+  border: 1px solid var(--border-color);
 }
 
-#contributorsTable td ul {
-  display: inline-block;
-  text-align: left;
-  margin: 0 auto;
-  padding-left: 1.2rem;
+#contributorsTable thead th {
+  background-color: var(--thead-bg-color);
+  font-weight: bold;
 }
 
-#contributorsTable td ul li {
-  margin-bottom: 0.2rem;
+#contributorsTable tbody tr {
+  background-color: var(--bg-color);
+}
+
+#contributorsTable tbody tr:nth-child(even) {
+  background-color: var(--row-alt-color);
 }
 
 /* ========================
-   Projects Toggle Styling
-======================== */
-.projects-toggle {
-  margin-top: 0.5rem;
-  text-align: left;
-}
-
-.projects-toggle summary {
-  cursor: pointer;
-  font-weight: bold;
-  color: #ccc;
-  padding: 0.3rem 0;
-  outline: none;
-}
-
-.projects-toggle[open] summary::after {
-  content: " ▲";
-}
-.projects-toggle summary::after {
-  content: " ▼";
-}
-
-.project-list {
-  padding-left: 1.5rem;
-  margin-top: 0.4rem;
-}
-
+   Project List
+========================= */
 .project-list li {
-  margin-bottom: 0.3rem;
-  line-height: 1.4;
+  border-bottom: 1px dashed var(--border-color);
 }
 
 .project-list a {
-  color: #66b1ff;
+  color: var(--link-color);
   text-decoration: none;
 }
 
 .project-list a:hover {
+  color: var(--link-hover);
   text-decoration: underline;
 }
 
 /* ========================
-   Responsive Tweaks
-======================== */
+   Avatar
+========================= */
+.avatar {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+/* ========================
+   Responsive
+========================= */
 @media (max-width: 600px) {
   #contributorsTable th,
   #contributorsTable td {
@@ -91,7 +110,8 @@ body {
     padding: 0.5rem;
   }
 
-  #contributorsTable td ul {
-    padding-left: 1rem;
+  .avatar {
+    width: 32px;
+    height: 32px;
   }
 }

--- a/static/css/members.css
+++ b/static/css/members.css
@@ -1,0 +1,134 @@
+/* ========================
+   Base Styles
+======================== */
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0 1rem;
+  background-color: #121212;
+  color: #eee;
+}
+
+/* ========================
+   Inputs: Search + Sort
+======================== */
+#searchInput,
+#sortOption {
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  margin: 0.5rem 0.5rem 0.5rem 0;
+  transition:
+    border-color 0.2s ease,
+    box-shadow 0.2s ease,
+    width 0.3s ease;
+}
+
+#searchInput {
+  width: 200px;
+}
+
+#searchInput:hover,
+#searchInput:focus {
+  border-color: #66afe9;
+  box-shadow: 0 0 5px rgba(102, 175, 233, 0.6);
+  width: 250px;
+}
+
+/* ========================
+   Community Summary Box
+======================== */
+.community-summary {
+  border: 1px solid #444;
+  padding: 0.5rem 1rem;
+  margin: 1rem 0;
+  background-color: #1e1e1e;
+  color: #eee;
+}
+
+/* ========================
+   Last Updated Text
+======================== */
+.last-updated {
+  font-style: italic;
+  margin-top: 1rem;
+  color: #aaa;
+}
+
+/* ========================
+   Table Styles
+======================== */
+.table-container {
+  overflow-x: auto;
+  margin-top: 1rem;
+  max-width: 100%;
+}
+
+#contributorsTable {
+  width: 100%;
+  border-collapse: collapse;
+  table-layout: fixed;
+}
+
+#contributorsTable th,
+#contributorsTable td {
+  border: 1px solid #444;
+  padding: 0.75rem;
+  text-align: left;
+  vertical-align: top;
+  word-wrap: break-word;
+}
+
+#contributorsTable th {
+  background-color: #1a1a1a;
+  font-weight: bold;
+  color: #fff;
+}
+
+/* Removed hover effect */
+#contributorsTable tbody tr {
+  transition: none;
+}
+
+/* ========================
+   List Styling
+======================== */
+ul {
+  padding-left: 1.2rem;
+  margin: 0;
+}
+
+/* ========================
+   Responsive Design
+======================== */
+@media (max-width: 600px) {
+  body {
+    font-size: 14px;
+  }
+
+  #searchInput,
+  #sortOption {
+    width: 100%;
+    margin: 0.5rem 0;
+  }
+
+  #searchInput:hover,
+  #searchInput:focus {
+    width: 100%;
+  }
+
+  .community-summary {
+    font-size: 14px;
+    padding: 0.5rem;
+  }
+
+  #contributorsTable th,
+  #contributorsTable td {
+    font-size: 13px;
+    padding: 0.5rem;
+  }
+
+  ul {
+    padding-left: 1rem;
+  }
+}

--- a/static/css/members.css
+++ b/static/css/members.css
@@ -2,133 +2,96 @@
    Base Styles
 ======================== */
 body {
-  font-family: Arial, sans-serif;
-  margin: 0;
-  padding: 0 1rem;
   background-color: #121212;
-  color: #eee;
+  color: var(--body-color, #eee);
 }
 
 /* ========================
-   Inputs: Search + Sort
-======================== */
-#searchInput,
-#sortOption {
-  padding: 0.5rem;
-  border: 1px solid #ccc;
-  border-radius: 4px;
-  margin: 0.5rem 0.5rem 0.5rem 0;
-  transition:
-    border-color 0.2s ease,
-    box-shadow 0.2s ease,
-    width 0.3s ease;
-}
-
-#searchInput {
-  width: 200px;
-}
-
-#searchInput:hover,
-#searchInput:focus {
-  border-color: #66afe9;
-  box-shadow: 0 0 5px rgba(102, 175, 233, 0.6);
-  width: 250px;
-}
-
-/* ========================
-   Community Summary Box
+   Summary and Metadata
 ======================== */
 .community-summary {
-  border: 1px solid #444;
-  padding: 0.5rem 1rem;
   margin: 1rem 0;
-  background-color: #1e1e1e;
-  color: #eee;
 }
 
-/* ========================
-   Last Updated Text
-======================== */
 .last-updated {
   font-style: italic;
-  margin-top: 1rem;
   color: #aaa;
+  margin-top: 1rem;
 }
 
 /* ========================
-   Table Styles
+   Table Styling
 ======================== */
-.table-container {
-  overflow-x: auto;
-  margin-top: 1rem;
-  max-width: 100%;
-}
-
-#contributorsTable {
-  width: 100%;
-  border-collapse: collapse;
-  table-layout: fixed;
-}
-
 #contributorsTable th,
 #contributorsTable td {
-  border: 1px solid #444;
-  padding: 0.75rem;
+  text-align: center;
+  vertical-align: middle;
+}
+
+#contributorsTable td ul {
+  display: inline-block;
   text-align: left;
-  vertical-align: top;
-  word-wrap: break-word;
-}
-
-#contributorsTable th {
-  background-color: #1a1a1a;
-  font-weight: bold;
-  color: #fff;
-}
-
-/* Removed hover effect */
-#contributorsTable tbody tr {
-  transition: none;
-}
-
-/* ========================
-   List Styling
-======================== */
-ul {
+  margin: 0 auto;
   padding-left: 1.2rem;
-  margin: 0;
+}
+
+#contributorsTable td ul li {
+  margin-bottom: 0.2rem;
 }
 
 /* ========================
-   Responsive Design
+   Projects Toggle Styling
+======================== */
+.projects-toggle {
+  margin-top: 0.5rem;
+  text-align: left;
+}
+
+.projects-toggle summary {
+  cursor: pointer;
+  font-weight: bold;
+  color: #ccc;
+  padding: 0.3rem 0;
+  outline: none;
+}
+
+.projects-toggle[open] summary::after {
+  content: " ▲";
+}
+.projects-toggle summary::after {
+  content: " ▼";
+}
+
+.project-list {
+  padding-left: 1.5rem;
+  margin-top: 0.4rem;
+}
+
+.project-list li {
+  margin-bottom: 0.3rem;
+  line-height: 1.4;
+}
+
+.project-list a {
+  color: #66b1ff;
+  text-decoration: none;
+}
+
+.project-list a:hover {
+  text-decoration: underline;
+}
+
+/* ========================
+   Responsive Tweaks
 ======================== */
 @media (max-width: 600px) {
-  body {
-    font-size: 14px;
-  }
-
-  #searchInput,
-  #sortOption {
-    width: 100%;
-    margin: 0.5rem 0;
-  }
-
-  #searchInput:hover,
-  #searchInput:focus {
-    width: 100%;
-  }
-
-  .community-summary {
-    font-size: 14px;
-    padding: 0.5rem;
-  }
-
   #contributorsTable th,
   #contributorsTable td {
     font-size: 13px;
     padding: 0.5rem;
   }
 
-  ul {
+  #contributorsTable td ul {
     padding-left: 1rem;
   }
 }


### PR DESCRIPTION
This PR adds a new **Members** page layout to display community contributor statistics in a structured and responsive format.

---

### Features Included

-  **Responsive table** displaying:
   - Username
   - Total contributions
   - Breakdown of commits, PRs, issues, and comments
-  **Search** by username
-  **Sort options** (alphabetical, most/least contributions)
-  **Community summary** box with aggregate stats
-  Mobile-friendly design with media queries

---

### Notes

- The `last updated` timestamp currently depends on the `remoteGeneratedAt` field in the data source – ensure it's available in the JSON.
- The layout was added under the **Members** section rather than **Contributions**, as that page already used a simple layout not suited for this logic.

Let me know if any adjustments are needed!
