### PR TITLE
fix(navbar): enable dropdown visibility

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -17,7 +17,7 @@ html, body {
 html[dir="rtl"] {
   .container,
   .container-fluid {
-    overflow-x: hidden;
+    overflow: visible; // fixed for lang and brightness menus to be visible
   }
 
   .row {


### PR DESCRIPTION
<img width="894" height="249" alt="image" src="https://github.com/user-attachments/assets/d2faf607-d868-4f14-8efb-e15166151fb6" />
The dropdown in the Hebrew page navbar is now visible  