### PR TITLE
fix(workflow): rebase before push in fetch-github-data

### DIFF
--- a/.github/workflows/fetch-github-data.yml
+++ b/.github/workflows/fetch-github-data.yml
@@ -53,6 +53,9 @@ jobs:
           git config --local user.name "github-actions[bot]"
           git add data/github_data.json
           git commit -m "chore: update GitHub data [skip ci]"
+          # Rebase onto latest main in case it moved (e.g. a PR merged while
+          # this workflow was running) so the push isn't rejected.
+          git pull --rebase origin main
           git push
 
       - name: Trigger Netlify Deploy


### PR DESCRIPTION
If a PR merges to main while the workflow is running (between checkout and push), the push gets rejected. Add a git pull --rebase origin main before push so the workflow recovers automatically.