### PR TITLE
fix(workflow): autostash before rebase in fetch-github-data

### DIFF
--- a/.github/workflows/fetch-github-data.yml
+++ b/.github/workflows/fetch-github-data.yml
@@ -55,7 +55,8 @@ jobs:
           git commit -m "chore: update GitHub data [skip ci]"
           # Rebase onto latest main in case it moved (e.g. a PR merged while
           # this workflow was running) so the push isn't rejected.
-          git pull --rebase origin main
+          # --autostash sidesteps unstaged dependency installs (package-lock).
+          git pull --rebase --autostash origin main
           git push
 
       - name: Trigger Netlify Deploy


### PR DESCRIPTION
Workflow npm-installs dev deps which modifies package-lock.json (unstaged), then git pull --rebase refused with 'unstaged changes'. Add --autostash to sidestep that.