### PR TITLE
fix: make showToast non-blocking and auto-dismissing

### DIFF
--- a/static/js/mentorship/toast.js
+++ b/static/js/mentorship/toast.js
@@ -108,4 +108,5 @@ export function showToast(message, then) {
   }
 
   btn.addEventListener('click', dismiss);
+  setTimeout(dismiss, 4000);
 }

--- a/static/js/mentorship/toast.js
+++ b/static/js/mentorship/toast.js
@@ -64,14 +64,6 @@ export function showBlockingMessage(message) {
 }
 
 export function showToast(message, then) {
-  const backdrop = document.createElement('div');
-  backdrop.style.cssText = `
-    position: fixed;
-    inset: 0;
-    background: rgba(0, 0, 0, 0.4);
-    z-index: 9998;
-  `;
-
   const el = document.createElement('div');
   el.dir = 'rtl';
   el.style.cssText = `
@@ -82,6 +74,7 @@ export function showToast(message, then) {
     z-index: 9999;
     min-width: 280px;
     max-width: 90vw;
+    pointer-events: auto;
   `;
   const alert = document.createElement('div');
   alert.className = 'alert alert-success shadow mb-0 d-flex align-items-center gap-3';
@@ -98,11 +91,9 @@ export function showToast(message, then) {
   alert.append(span, btn);
   el.appendChild(alert);
 
-  document.body.appendChild(backdrop);
   document.body.appendChild(el);
 
   function dismiss() {
-    backdrop.remove();
     el.remove();
     then();
   }


### PR DESCRIPTION
## Summary
- Auto-dismiss `showToast` popups after 4 seconds instead of requiring manual close
- Remove the blocking backdrop overlay so users can continue interacting with the page while the toast is visible

## Test plan
- [ ] Trigger a success toast (e.g. login, registration, profile save) and verify it auto-dismisses after ~4 seconds
- [ ] Verify the page is interactive while the toast is visible
- [ ] Verify the close button still dismisses the toast immediately
- [ ] Verify the `then` callback fires on both manual and auto dismiss

🤖 Generated with [Claude Code](https://claude.com/claude-code)